### PR TITLE
chore: revert running this workflow after sync workflow

### DIFF
--- a/.github/workflows/list-images.yaml
+++ b/.github/workflows/list-images.yaml
@@ -5,11 +5,6 @@ on:
       - '.github/workflows/list-images.yaml'
       - 'platform-apps/charts/**'
 
-  workflow_run:
-    workflows: [sync upstream with PR]
-    types:
-      - completed
-
 name: list images
 
 jobs:


### PR DESCRIPTION
because if sync workflow is triggered manually on main this workflow fails. Also, there is no reason why this should run after sync