### PR TITLE
fix(vault): oidc-backend-role needs to run later, because of #1074

### DIFF
--- a/platform-apps/charts/vault/templates/crossplane/cp-authbackend-oidc.yaml
+++ b/platform-apps/charts/vault/templates/crossplane/cp-authbackend-oidc.yaml
@@ -44,7 +44,7 @@ metadata:
   name: oidc-backend-role
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "4"
+    argocd.argoproj.io/sync-wave: "7"
 spec:
   providerConfigRef:
     name: vault-crossplane-providerconfig


### PR DESCRIPTION
fixes #1074 