### PR TITLE
feat: add ignoreDifferences to argo-rollouts to prevent outofsync in …

### DIFF
--- a/platform-apps/target-chart/values-demo-metalstack.yaml
+++ b/platform-apps/target-chart/values-demo-metalstack.yaml
@@ -66,6 +66,11 @@ applications:
     namespaceResourceTracking: false
 
   - name: argo-rollouts
+    ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jsonPointers:
+      - /spec/preserveUnknownFields
       
   - name: grafana
     annotations:

--- a/platform-apps/target-chart/values-kind.yaml
+++ b/platform-apps/target-chart/values-kind.yaml
@@ -62,6 +62,11 @@ applications:
     namespaceResourceTracking: false
 
   - name: argo-rollouts
+    ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jsonPointers:
+      - /spec/preserveUnknownFields
       
   - name: kyverno
     syncOptions:

--- a/platform-apps/target-chart/values-metalstack.yaml
+++ b/platform-apps/target-chart/values-metalstack.yaml
@@ -40,6 +40,11 @@ applications:
     namespaceResourceTracking: false
 
   - name: argo-rollouts
+    ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jsonPointers:
+      - /spec/preserveUnknownFields
 
   - name: grafana
     annotations:


### PR DESCRIPTION
…argocd >= 3.0

BREAKING CHANGE: in every target-chart values file where argo-rollouts gets installed, you need to add the ignoreDifferences attribute described in https://github.com/suxess-it/kubriX/issues/1296