### PR TITLE
test: Enhance delivery-tests.yaml with SSL certificate checks

### DIFF
--- a/platform-apps/charts/testkube/templates/delivery-tests.yaml
+++ b/platform-apps/charts/testkube/templates/delivery-tests.yaml
@@ -8,5 +8,8 @@ spec:
     - run:
         image: "curlimages/curl:7.78.0"
         shell: |
+          cat /etc/ssl/custom/ca.crt
+          echo ${CURL_CA_BUNDLE}
+          echo | openssl s_client -showcerts -servername argocd.127-0-0-1.nip.io -connect argocd.127-0-0-1.nip.io:443 2>/dev/null | openssl x509 -inform pem -noout -text
           curl https://argocd.127-0-0-1.nip.io
 {{- end }}


### PR DESCRIPTION
Add commands to display custom CA certificate and Argocd server certificate.