### PR TITLE
chore(release-please): don't explicitly set release sha1 because kubr…

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "last-release-sha": "ab60148d03a5b3a11dcac83982515f49396c46c0",
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
…iX-prime has a different one